### PR TITLE
Switch to ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ A telephone over [Hyperbeam](https://github.com/mafintosh/hyperbeam)
 npm install -g hyperphone
 ```
 
-Needs sox installed.
+Needs ffmpeg installed.
 
 On mac:
 
 ```sh
-brew install sox
+brew install ffmpeg
 ```
 
 On linux:
 
 ```sh
-sudo apt-get install sox
+sudo apt-get install ffmpeg
 ```
 
 ## Usage


### PR DESCRIPTION
Not sure what latency you've seen with sox on the mac, but this helped me get audio latency down to ~100 ms from >1s using two of my linux devices on this configuration. This can be lowered by removing the anti-click sound filter (which also removes most feedback 🙉), but leaving that in there.

Does need confirmation these assumed mac & win ffmpeg options work to merge.